### PR TITLE
When passing https:// credentials into git, don't write them to the lockfile.

### DIFF
--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -290,9 +290,8 @@ module Bundler
       end
 
       def safe_uri
-        uri.gsub(/(?<schema>https?:\/\/)\w+:\w+@/, '\k<schema>')
+        uri.gsub(%r{(?<schema>https?://)\w+:\w+@}, '\k<schema>')
       end
-
     end
   end
 end

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -36,7 +36,7 @@ module Bundler
 
       def to_lock
         out = "GIT\n"
-        out << "  remote: #{@uri}\n"
+        out << "  remote: #{safe_uri}\n"
         out << "  revision: #{revision}\n"
         %w(ref branch tag submodules).each do |opt|
           out << "  #{opt}: #{options[opt]}\n" if options[opt]
@@ -288,6 +288,11 @@ module Bundler
       def git_proxy
         @git_proxy ||= GitProxy.new(cache_path, uri, ref, cached_revision, self)
       end
+
+      def safe_uri
+        uri.gsub(/(?<schema>https?:\/\/)\w+:\w+@/, '\k<schema>')
+      end
+
     end
   end
 end

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -290,7 +290,7 @@ module Bundler
       end
 
       def safe_uri
-        uri.gsub(%r{(?<schema>https?://)\w+:\w+@}, '\k<schema>')
+        uri.gsub(%r{(https?://)\w+:\w+@}, '\1')
       end
     end
   end

--- a/spec/bundler/source/git_spec.rb
+++ b/spec/bundler/source/git_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Bundler::Source::Git do
+
+  describe "#to_lock" do
+    let(:git_proxy) { double(:git_proxy, revision: "ABC123") }
+
+    it "removes credentials from https uri" do
+      expect(Bundler::Source::Git::GitProxy).to receive(:new).exactly(2).times.and_return(git_proxy)
+      expect(Bundler).to receive(:requires_sudo?).exactly(2).times.and_return(false)
+      expect(Bundler).to receive(:cache).exactly(2).times.and_return(Pathname.new("Idontcare"))
+      {
+        "https://u:p@github.com/foo/foo.git" => "https://github.com/foo/foo.git",
+        "http://u:p@github.com/foo/foo.git" => "http://github.com/foo/foo.git"
+      }.each do |uri_in, uri_out|
+        g = described_class.new({"revision" => "ABC123", "uri" => uri_in})
+        expect(g.to_lock).to eq(<<-STR)
+GIT
+  remote: #{uri_out}
+  revision: ABC123
+  specs:
+STR
+      end
+    end
+  end
+end

--- a/spec/bundler/source/git_spec.rb
+++ b/spec/bundler/source/git_spec.rb
@@ -4,7 +4,7 @@ describe Bundler::Source::Git do
   describe "#to_lock" do
     let(:git_proxy) { double(:git_proxy, "revision" => "ABC123") }
 
-    it "removes credentials from https uri" do
+    it "removes credentials from uri" do
       expect(Bundler::Source::Git::GitProxy).to receive(:new).exactly(2).times.and_return(git_proxy)
       expect(Bundler).to receive(:requires_sudo?).exactly(2).times.and_return(false)
       expect(Bundler).to receive(:cache).exactly(2).times.and_return(Pathname.new("Idontcare"))

--- a/spec/bundler/source/git_spec.rb
+++ b/spec/bundler/source/git_spec.rb
@@ -4,14 +4,11 @@ describe Bundler::Source::Git do
   describe "#to_lock" do
     let(:git_proxy) { double(:git_proxy, "revision" => "ABC123") }
 
-    it "removes credentials from uri" do
-      expect(Bundler::Source::Git::GitProxy).to receive(:new).exactly(2).times.and_return(git_proxy)
-      expect(Bundler).to receive(:requires_sudo?).exactly(2).times.and_return(false)
-      expect(Bundler).to receive(:cache).exactly(2).times.and_return(Pathname.new("Idontcare"))
-      {
-        "https://u:p@github.com/foo/foo.git" => "https://github.com/foo/foo.git",
-        "http://u:p@github.com/foo/foo.git" => "http://github.com/foo/foo.git"
-      }.each do |uri_in, uri_out|
+    shared_examples_for "GitHub URIs" do |uri_in, uri_out|
+      it "removes the credentials" do
+        expect(Bundler::Source::Git::GitProxy).to receive(:new).and_return(git_proxy)
+        expect(Bundler).to receive(:requires_sudo?).and_return(false)
+        expect(Bundler).to receive(:cache).and_return(Pathname.new("Idontcare"))
         g = described_class.new("revision" => "ABC123", "uri" => uri_in)
         expect(g.to_lock).to eq(<<-STR)
 GIT
@@ -20,6 +17,14 @@ GIT
   specs:
 STR
       end
+    end
+
+    context "with https" do
+      it_behaves_like "GitHub URIs", "https://u:p@github.com/foo/foo.git", "https://github.com/foo/foo.git"
+    end
+
+    context "with http" do
+      it_behaves_like "GitHub URIs", "http://u:p@github.com/foo/foo.git", "http://github.com/foo/foo.git"
     end
   end
 end

--- a/spec/bundler/source/git_spec.rb
+++ b/spec/bundler/source/git_spec.rb
@@ -1,9 +1,8 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Bundler::Source::Git do
-
   describe "#to_lock" do
-    let(:git_proxy) { double(:git_proxy, revision: "ABC123") }
+    let(:git_proxy) { double(:git_proxy, "revision" => "ABC123") }
 
     it "removes credentials from https uri" do
       expect(Bundler::Source::Git::GitProxy).to receive(:new).exactly(2).times.and_return(git_proxy)
@@ -13,7 +12,7 @@ describe Bundler::Source::Git do
         "https://u:p@github.com/foo/foo.git" => "https://github.com/foo/foo.git",
         "http://u:p@github.com/foo/foo.git" => "http://github.com/foo/foo.git"
       }.each do |uri_in, uri_out|
-        g = described_class.new({"revision" => "ABC123", "uri" => uri_in})
+        g = described_class.new("revision" => "ABC123", "uri" => uri_in)
         expect(g.to_lock).to eq(<<-STR)
 GIT
   remote: #{uri_out}

--- a/spec/bundler/source/git_spec.rb
+++ b/spec/bundler/source/git_spec.rb
@@ -26,5 +26,9 @@ STR
     context "with http" do
       it_behaves_like "GitHub URIs", "http://u:p@github.com/foo/foo.git", "http://github.com/foo/foo.git"
     end
+
+    context "without credentials" do
+      it_behaves_like "GitHub URIs", "http://github.com/foo/foo.git", "http://github.com/foo/foo.git"
+    end
   end
 end


### PR DESCRIPTION
Context:
Currently bundler writes sensitive credentials in the lockfile when passed in as environment variables. 

`Gemfile`

```
gem foo,  git: "https://#{ENV[GITHUB_TOKEN]}@github.com/foo/foo.git"
```

`Gemfile.lock`

```
 GIT
-  remote: git@github.com:foo/foo.git
+  remote: https://<sensitive_token>:x-oauth-basic@github.com/foo/foo.git
   revision: b668ddd4661836eb31ec780160048d2d41f4393b
   branch: master
   specs:
```

This should never happen.

Rather than using `bundle config` which stores clear text sensitive information, I would rather be able to pass in gpg encrypted credentials file as ENV values.

Change:
This patch sanitises those credentials from the lockfile at the time the lockfile is written.

Relates to: https://github.com/bundler/bundler/issues/3609
