### PR TITLE
Sanitize lockfile

### DIFF
--- a/spec/bundler/source/git_spec.rb
+++ b/spec/bundler/source/git_spec.rb
@@ -4,14 +4,11 @@ describe Bundler::Source::Git do
   describe "#to_lock" do
     let(:git_proxy) { double(:git_proxy, "revision" => "ABC123") }
 
-    it "removes credentials from uri" do
-      expect(Bundler::Source::Git::GitProxy).to receive(:new).exactly(2).times.and_return(git_proxy)
-      expect(Bundler).to receive(:requires_sudo?).exactly(2).times.and_return(false)
-      expect(Bundler).to receive(:cache).exactly(2).times.and_return(Pathname.new("Idontcare"))
-      {
-        "https://u:p@github.com/foo/foo.git" => "https://github.com/foo/foo.git",
-        "http://u:p@github.com/foo/foo.git" => "http://github.com/foo/foo.git"
-      }.each do |uri_in, uri_out|
+    shared_examples_for "GitHub URIs" do |uri_in, uri_out|
+      it "removes the credentials" do
+        expect(Bundler::Source::Git::GitProxy).to receive(:new).and_return(git_proxy)
+        expect(Bundler).to receive(:requires_sudo?).and_return(false)
+        expect(Bundler).to receive(:cache).and_return(Pathname.new("Idontcare"))
         g = described_class.new("revision" => "ABC123", "uri" => uri_in)
         expect(g.to_lock).to eq(<<-STR)
 GIT
@@ -20,6 +17,14 @@ GIT
   specs:
 STR
       end
+    end
+
+    context "with https" do
+      it_behaves_like "GitHub URIs", "https://u:p@github.com/foo/foo.git", "https://github.com/foo/foo.git"
+    end
+
+    context "with http" do
+      it_behaves_like "GitHub URIs", "http://u:p@github.com/foo/foo.git", "http://github.com/foo/foo.git"
     end
   end
 end

--- a/spec/bundler/source/git_spec.rb
+++ b/spec/bundler/source/git_spec.rb
@@ -26,5 +26,9 @@ STR
     context "with http" do
       it_behaves_like "GitHub URIs", "http://u:p@github.com/foo/foo.git", "http://github.com/foo/foo.git"
     end
+
+    context "without credentials" do
+      it_behaves_like "GitHub URIs", "http://github.com/foo/foo.git", "http://github.com/foo/foo.git"
+    end
   end
 end


### PR DESCRIPTION
# Context

Reviewing https://github.com/bundler/bundler/pull/4107 , I agreed with @nemski's comments about separate examples.

I also felt it would be useful to give an example when there were no credentials in the URI
# Change

Rather than comment on the PR, I figured I'd PR against it.
# Confirmation

```
Bundler::Source::Git
  #to_lock
    with https
      behaves like GitHub URIs
        removes the credentials
    with http
      behaves like GitHub URIs
        removes the credentials
    without credentials
      behaves like GitHub URIs
        removes the credentials


Retried examples: 0

Finished in 0.71212 seconds (files took 0.64609 seconds to load)
3 examples, 0 failures
```
